### PR TITLE
ci: update renovate config to pull helm chart version from help registry

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,18 +13,27 @@
     },
     {
       "customType": "regex",
-      "description": "Update helm chart version to latest in variables.tf",
+      "description": "Update reloader helm chart version to latest in variables.tf",
       "fileMatch": ["variables.tf$"],
-      "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?default\\s*=\\s*\"(?<currentValue>.*)\"\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "matchStrings": ["default\\s*=\\s*\"(?<currentValue>.*?)\"\\s*# registryUrl: stakater.github.io/stakater-charts\\n"],
+      "depNameTemplate": "reloader",
+      "datasourceTemplate": "helm",
+      "registryUrlTemplate": "https://stakater.github.io/stakater-charts"
+    },
+    {
+      "customType": "regex",
+      "description": "Update ESO helm chart version to latest in variables.tf",
+      "fileMatch": ["variables.tf$"],
+      "matchStrings": ["default\\s*=\\s*\"(?<currentValue>.*?)\"\\s*# registryUrl: charts.external-secrets.io\\n"],
+      "depNameTemplate": "external-secrets",
+      "datasourceTemplate": "helm",
+      "registryUrlTemplate": "https://charts.external-secrets.io"
     }
   ],
   "packageRules": [
     {
       "description": "Bundle ESO and Reloader images + helm chart updates into the same PR",
-      "matchPackageNames": ["external-secrets/external-secrets", "stakater/Reloader", "ghcr.io/external-secrets/external-secrets", "ghcr.io/stakater/reloader"],
+      "matchPackageNames": ["external-secrets/external-secrets", "stakater/Reloader", "ghcr.io/external-secrets/external-secrets", "ghcr.io/stakater/reloader", "external-secrets", "reloader"],
       "groupName": "Charts and Images",
       "commitMessageExtra": "to latest",
       "group": true

--- a/variables.tf
+++ b/variables.tf
@@ -95,9 +95,8 @@ variable "eso_chart_location" {
 variable "eso_chart_version" {
   type        = string
   description = "The version of the External Secrets Operator Helm chart. Ensure that the chart version is compatible with the image version specified in eso_image_version."
-  # renovate: datasource=github-tags depName=external-secrets/external-secrets versioning="regex:^helm-chart-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
-  default  = "0.15.1"
-  nullable = false
+  default     = "0.15.1" # registryUrl: charts.external-secrets.io
+  nullable    = false
 }
 
 ############################################################################################################
@@ -223,6 +222,6 @@ variable "reloader_chart_location" {
 variable "reloader_chart_version" {
   type        = string
   description = "The version of the Reloader Helm chart. Ensure that the chart version is compatible with the image version specified in reloader_image_version."
-  default     = "2.0.0"
+  default     = "2.0.0" # registryUrl: stakater.github.io/stakater-charts
   nullable    = false
 }


### PR DESCRIPTION
### Description

See https://github.com/terraform-ibm-modules/terraform-ibm-external-secrets-operator/pull/72

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
