### PR TITLE
Fix of breaking change during module upgrade

### DIFF
--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,5 @@
+# this move section is needed to avoid es-operator destroy during module upgrade
+moved {
+  from = module.external_secrets_operator.kubernetes_namespace.eso_namespace[0]
+  to   = module.external_secrets_operator.module.eso_namespace[0].kubernetes_namespace.create_namespace["es-operator"]
+}


### PR DESCRIPTION
### Description

This move block fixes the breaking change that would occur in the case of an upgrade from previous module version to this one, that would cause the namespace where ESO is deployed to be destroyed and ESO to be redeployed: this action would cause issues on existing CRs that wouldn't be cleaned up without a clean undeployment

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added moved block to fix the breaking change that would occur in the case of an upgrade from previous module version to this one, that would cause the namespace where ESO is deployed to be destroyed and ESO to be redeployed

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
