### PR TITLE
Added an additional check for the trusted profile payload

### DIFF
--- a/modules/eso-external-secret/main.tf
+++ b/modules/eso-external-secret/main.tf
@@ -67,7 +67,7 @@ locals {
         "username" : "iamapikey", "password" : "{{ .secretid_${index} }}", "email" : (element.es_container_registry_email)
       }
       :
-      (element.trusted_profile != null && element.trusted_profile != "") ?
+      (element.trusted_profile != null && element.trusted_profile != "" && var.sm_secret_type == "trusted_profile") ?
       {
         "username" : element.trusted_profile, "password" : "{{ .secretid_${index} }}"
       } :


### PR DESCRIPTION
### Description


The provided Terraform expression conditionally constructs a data_payload_chain_map based on the value of local.is_dockerjsonconfig_chain. If it's true, an auths map is generated by iterating over var.es_container_registry_secrets_chain. For each registry secret, the corresponding es_container_registry is used as the key, and its value is determined based on the presence of es_container_registry_email and trusted_profile. If es_container_registry_email is defined and non-empty, the credentials include username, password, and email. If not, but a trusted_profile is specified, then the credentials fall back to using trusted_profile as the username with the templated password. Otherwise, a default username of iamapikey is used. However, this logic has a flaw: the trusted_profile block will be applied even when the secret type is iam_credentials, which may lead to incorrect or unintended authentication configuration. The expression lacks an explicit check to distinguish between secret types, potentially resulting in misconfigured payloads when trusted_profile is present but not applicable.


```
  data_payload_chain_map = local.is_dockerjsonconfig_chain == true ? {
    "auths" : {
      for index, element in var.es_container_registry_secrets_chain :
      element.es_container_registry => (element.es_container_registry_email != null && element.es_container_registry_email != "") ?
      {
        "username" : "iamapikey", "password" : "{{ .secretid_${index} }}", "email" : (element.es_container_registry_email)
      }
      :
      (element.trusted_profile != null && element.trusted_profile != "") ?
      {
        "username" : element.trusted_profile, "password" : "{{ .secretid_${index} }}"
      } :
      }:
      {
        "username" : "iamapikey", "password" : "{{ .secretid_${index} }}"
      }
    }
  } : {}

```

Due to this I have added the following line to avoid the mishap

```
(element.trusted_profile != null && element.trusted_profile != "" && var.sm_secret_type == "trusted_profile")
```

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
