### PR TITLE
fix: fixed resources dependency to avoid errors when undeploying

### DIFF
--- a/modules/eso-secretstore/main.tf
+++ b/modules/eso-secretstore/main.tf
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "eso_secretsstore_secret" {
 ### Define secret store used to connect with SM instance for apikey auth
 resource "helm_release" "external_secret_store_apikey" {
   count     = var.eso_authentication == "api_key" ? 1 : 0
-  name      = substr(join("-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
+  name      = substr(join("ak-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
   namespace = var.sstore_namespace
   chart     = "${path.module}/../../chart/${local.helm_raw_chart_name}"
   version   = local.helm_raw_chart_version
@@ -52,7 +52,7 @@ resource "helm_release" "external_secret_store_apikey" {
 # Trusted profile authentication Use ContainerAuth with CRI based authentication (trusted profile support)
 resource "helm_release" "external_secret_store_tp" {
   count     = var.eso_authentication == "trusted_profile" ? 1 : 0
-  name      = substr(join("-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
+  name      = substr(join("tp-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
   namespace = var.sstore_namespace
   chart     = "${path.module}/../../chart/${local.helm_raw_chart_name}"
   version   = local.helm_raw_chart_version

--- a/modules/eso-secretstore/main.tf
+++ b/modules/eso-secretstore/main.tf
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "eso_secretsstore_secret" {
 ### Define secret store used to connect with SM instance for apikey auth
 resource "helm_release" "external_secret_store_apikey" {
   count     = var.eso_authentication == "api_key" ? 1 : 0
-  name      = substr(join("ak-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
+  name      = substr(join("-", [var.sstore_namespace, "ak", var.sstore_helm_rls_name]), 0, 52)
   namespace = var.sstore_namespace
   chart     = "${path.module}/../../chart/${local.helm_raw_chart_name}"
   version   = local.helm_raw_chart_version
@@ -52,7 +52,7 @@ resource "helm_release" "external_secret_store_apikey" {
 # Trusted profile authentication Use ContainerAuth with CRI based authentication (trusted profile support)
 resource "helm_release" "external_secret_store_tp" {
   count     = var.eso_authentication == "trusted_profile" ? 1 : 0
-  name      = substr(join("tp-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
+  name      = substr(join("-", [var.sstore_namespace, "tp", var.sstore_helm_rls_name]), 0, 52)
   namespace = var.sstore_namespace
   chart     = "${path.module}/../../chart/${local.helm_raw_chart_name}"
   version   = local.helm_raw_chart_version

--- a/modules/eso-secretstore/main.tf
+++ b/modules/eso-secretstore/main.tf
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "eso_secretsstore_secret" {
 ### Define secret store used to connect with SM instance for apikey auth
 resource "helm_release" "external_secret_store_apikey" {
   count     = var.eso_authentication == "api_key" ? 1 : 0
-  name      = substr(join("-", [var.sstore_namespace, "ak", var.sstore_helm_rls_name]), 0, 52)
+  name      = substr(join("-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
   namespace = var.sstore_namespace
   chart     = "${path.module}/../../chart/${local.helm_raw_chart_name}"
   version   = local.helm_raw_chart_version
@@ -52,7 +52,7 @@ resource "helm_release" "external_secret_store_apikey" {
 # Trusted profile authentication Use ContainerAuth with CRI based authentication (trusted profile support)
 resource "helm_release" "external_secret_store_tp" {
   count     = var.eso_authentication == "trusted_profile" ? 1 : 0
-  name      = substr(join("-", [var.sstore_namespace, "tp", var.sstore_helm_rls_name]), 0, 52)
+  name      = substr(join("-", [var.sstore_namespace, var.sstore_helm_rls_name]), 0, 52)
   namespace = var.sstore_namespace
   chart     = "${path.module}/../../chart/${local.helm_raw_chart_name}"
   version   = local.helm_raw_chart_version

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -617,7 +617,7 @@ module "eso_clustersecretsstore" {
   service_endpoints                 = var.service_endpoints
   clusterstore_trusted_profile_name = each.value.trusted_profile_name != null && each.value.trusted_profile_name != "" ? each.value.trusted_profile_name : null
   depends_on = [
-    module.external_secrets_operator
+    module.external_secrets_operator, module.cluster_secrets_store_namespace
   ]
 }
 
@@ -633,7 +633,7 @@ module "eso_secretsstore" {
       "namespace" : secrets_store.namespace
     }
   })
-  depends_on                  = [module.external_secrets_operator]
+  depends_on                  = [module.external_secrets_operator, module.secrets_store_namespace]
   source                      = "../../modules/eso-secretstore"
   eso_authentication          = each.value.authentication
   region                      = local.sm_region


### PR DESCRIPTION
### Description

fixed resources dependency in DA code to avoid errors during undeploying when the namespace of secretstore is destroyed before the apikey secret stored in it

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

fixed resources dependency in DA code to avoid errors during undeploying when the namespace of secretstore is destroyed before the apikey secret stored in it

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
