### PR TITLE
fix: removed yamldecode from reloader custom values

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -306,5 +306,5 @@ resource "helm_release" "pod_reloader" {
   )
 
   # Set the values attribute conditionally
-  values = var.reloader_custom_values != null ? yamldecode(var.reloader_custom_values) : []
+  values = var.reloader_custom_values != null ? [var.reloader_custom_values] : []
 }


### PR DESCRIPTION
### Description

In order to fix a problem with setting custom values for reloader configuration we need to remove yamldecode method: this generates a terraform structure, this means that the input string must be a complex yaml with a resulting list. By removing it and allowing adopters to pass yaml strings using heredoc or passing the output of yamlencode would allow to provide the needed values in a more clean way

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

removed yamldecode from reloader custom values

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
